### PR TITLE
Replace hardcoded '$' and 'USD' in the Custom Amount section of

### DIFF
--- a/lbmgiftcard-core/gc_balanceGC.html
+++ b/lbmgiftcard-core/gc_balanceGC.html
@@ -167,7 +167,7 @@
 						<!--START: addFundsButton-->
 						<div class="col-sm-4" id="showAddFundsButton">
 							<!-- <a href="" class="btn btn-default btn-inverse gc-field-submit" id="showAddFunds">$ Add Funds</a> -->
-							<input type="button" value="$ Add Funds" class="btn btn-default btn-inverse gc-field-submit" id="showAddFunds">
+							<input type="button" value="[priceCurrency] Add Funds" class="btn btn-default btn-inverse gc-field-submit" id="showAddFunds">
 						</div>
 						<!--END: addFundsButton-->
 						<div class="col-sm-4" id="showActivityButton">
@@ -571,7 +571,7 @@ input.txtBoxStyle.form-control {
 
 	function selectAmountOption(optionLabelItem){
 		jQuery('#addFundsAmount').empty();
-		jQuery('#addFundsAmount').append(currencySymbol + optionLabelItem.innerText.replace('$', '').trim());
+		jQuery('#addFundsAmount').append(currencySymbol + optionLabelItem.innerText.replace(/[^0-9.]/g, '').trim());
 
 		if(jQuery('#specialamount'))
 			jQuery('#specialamount').val('');

--- a/lbmgiftcard-core/listing_0.html
+++ b/lbmgiftcard-core/listing_0.html
@@ -1677,6 +1677,7 @@
 <!--END: recaptcharobot_js-->
 
 <script>
+currency_symbol = jQuery('body').data('currency') || currency_symbol || '$';
 var OriginalImage = jQuery('#listing_main_image_link').attr('href') ?? '';
 function SelectSwatch(id) {
     var imagepath = jQuery('#swatch-image-' + id).val();

--- a/lbmgiftcard-core/listing_0.html
+++ b/lbmgiftcard-core/listing_0.html
@@ -658,16 +658,18 @@
 									  <span class="range-slider__value">0</span>
 									</div>
 									<input type="hidden" size="3" name="qty-0" value="1" onChange="validateValues(document.add,1);" class="form-control" />
-									<label for="text[oname]" style="margin-top: 10px;font-weight: 300;">Enter whole amount between $<span id="minVal"></span> - $<span id="maxVal"></span> USD</label>
+									<label for="text[oname]" style="margin-top: 10px;font-weight: 300;">Enter whole amount between <span id="minVal"></span> - <span id="maxVal"></span></label>
                                 </div>
 								<script>
 								var ex1value = jQuery("#et1").text();
 								var ex2value = jQuery("#et2").text();
+								var gcCurrencySymbol = jQuery('body').data('currency') || '$';
+                                var gcCurrencyCode = (typeof _3d_item !== 'undefined' && _3d_item.currency) ? _3d_item.currency : 'USD';
 								jQuery("#rangeInput").attr("value", ex1value);
 								jQuery("#rangeInput").attr("min", ex1value);
 								jQuery("#rangeInput").attr("max", ex2value);
-								jQuery("#minVal").text(ex1value);
-								jQuery("#maxVal").text(ex2value);
+								jQuery("#minVal").text(gcCurrencySymbol + ex1value);
+								jQuery("#maxVal").text(gcCurrencySymbol + ex2value + " " + gcCurrencyCode);
 								var rangeSlider = function(){
 								  var slider = jQuery('.range-slider'),
 									  range = jQuery('.range-slider__range'),
@@ -677,11 +679,11 @@
 
 									value.each(function(){
 									  var value = jQuery(".range-slider__range").attr('value');
-									  jQuery(this).html("$" + value);
+									  jQuery(this).html(gcCurrencySymbol + value);
 									});
 
 									range.on('input.range-slider__range', function(){
-									  jQuery(this).next(value).html("$" + this.value);
+									  jQuery(this).next(value).html(gcCurrencySymbol + this.value);
 									});
 								  });
 								};
@@ -1315,7 +1317,7 @@
 
                             <div id="filteredSearchResults" style="display: none;">
                                 <span class="btn btn-primary filterRemover" data-filtertype="1"><b id="StarRating">4 Stars</b></span>
-                                <span class="btn btn-default" onclick="ShowStarRating('');"><b>Clear Filter</b> <span data-filtertype="6" class="filterRemover">×</span></span>
+                                <span class="btn btn-default" onclick="ShowStarRating('');"><b>Clear Filter</b> <span data-filtertype="6" class="filterRemover">ï¿½</span></span>
                             </div>
                         </div>
                         <div class="col-md-6 average-customer-rating-sm">
@@ -1807,7 +1809,7 @@ function checkPrevPurch(userId, caId) {
 <style>
 .embed-responsive-bycustom 
 {
- padding-bottom: 85%;
+ï¿½padding-bottom: 85%;
 }
 .range-slider {
   margin: 30px 0 0 0%;

--- a/lbmgiftcard-core/listing_0.html
+++ b/lbmgiftcard-core/listing_0.html
@@ -1317,7 +1317,7 @@
 
                             <div id="filteredSearchResults" style="display: none;">
                                 <span class="btn btn-primary filterRemover" data-filtertype="1"><b id="StarRating">4 Stars</b></span>
-                                <span class="btn btn-default" onclick="ShowStarRating('');"><b>Clear Filter</b> <span data-filtertype="6" class="filterRemover">�</span></span>
+                                <span class="btn btn-default" onclick="ShowStarRating('');"><b>Clear Filter</b> <span data-filtertype="6" class="filterRemover">×</span></span>
                             </div>
                         </div>
                         <div class="col-md-6 average-customer-rating-sm">
@@ -1809,7 +1809,7 @@ function checkPrevPurch(userId, caId) {
 <style>
 .embed-responsive-bycustom 
 {
-�padding-bottom: 85%;
+    padding-bottom: 85%;
 }
 .range-slider {
   margin: 30px 0 0 0%;

--- a/lbmgiftcard-core/listing_99.html
+++ b/lbmgiftcard-core/listing_99.html
@@ -1102,6 +1102,9 @@
 <!--END: recaptcharobot_js-->
 
 <script>
+// Ensure currency_symbol has a fallback when the store's currency setting is empty
+currency_symbol = jQuery('body').data('currency') || currency_symbol || '$';
+
 function check_and_add_custom_gc(formx)
 {
     //perform preliminary validation - customized for GC shops

--- a/lbmgiftcard-core/listing_99.html
+++ b/lbmgiftcard-core/listing_99.html
@@ -635,7 +635,7 @@
 									  <span class="range-slider__value">0</span>
 									</div>
 									<input type="hidden" size="3" name="qty-0" value="1" onChange="validateValues(document.add,1);" class="form-control" />
-									<label for="text[oname]" style="margin-top: 10px;font-weight: 300;">Enter whole amount between $<span id="minVal"></span> - $<span id="maxVal"></span> USD</label>
+									<label for="text[oname]" style="margin-top: 10px;font-weight: 300;">Enter whole amount between <span id="minVal"></span> - <span id="maxVal"></span></label>
                                 </div>
                                 <script>
                                     if (typeof rangeSlider === "function")
@@ -1237,22 +1237,25 @@ function checkPrevPurch(userId, caId) {
             jQuery("#rangeInput").attr("step", step); // set step attribute on input
         }
       
+        var gcCurrencySymbol = jQuery('body').data('currency') || '$';
+        var gcCurrencyCode = (typeof _3d_item !== 'undefined' && _3d_item.currency) ? _3d_item.currency : 'USD';
+
         jQuery("#rangeInput").attr("value", min);
         jQuery("#rangeInput").attr("min", min);
         jQuery("#rangeInput").attr("max", max);
-        jQuery("#minVal").text(min);
-        jQuery("#maxVal").text(max);
-                
+        jQuery("#minVal").text(gcCurrencySymbol + min);
+        jQuery("#maxVal").text(gcCurrencySymbol + max + " " + gcCurrencyCode);
+
         var slider = jQuery('.range-slider'),
             range = jQuery('.range-slider__range'),
             value = jQuery('.range-slider__value');
         slider.each(function(){
             value.each(function(){
                 var value = jQuery(".range-slider__range").attr('value');
-                jQuery(this).html("$" + value);
+                jQuery(this).html(gcCurrencySymbol + value);
             });
             range.on('input.range-slider__range', function(){
-                jQuery(this).next(value).html("$" + this.value);
+                jQuery(this).next(value).html(gcCurrencySymbol + this.value);
             });
         });
     };


### PR DESCRIPTION
  Replace hardcoded '$' and 'USD' in the Custom Amount section of
  listing_0.html and listing_99.html with dynamic values read from
  the store's currency symbol (body data-currency) and currency code
  (_3d_item.currency), so the hint text and slider bubble reflect the
  merchant's configured currency instead of always showing USD.